### PR TITLE
Replacing global type declarations with types file.

### DIFF
--- a/src/cosmos-keys.ts
+++ b/src/cosmos-keys.ts
@@ -1,10 +1,9 @@
-/// <reference path="cosmos-keys.d.ts" />
-
 import * as bip39 from 'bip39'
 import * as bip32 from 'bip32'
 import * as bech32 from 'bech32'
 import * as secp256k1 from 'secp256k1'
 import * as CryptoJS from 'crypto-js'
+import { Wallet, StdSignMsg, KeyPair } from './types';
 
 const hdPathAtom = `m/44'/118'/0'/0/0` // key controlling ATOM allocation
 

--- a/src/cosmos-keystore.ts
+++ b/src/cosmos-keystore.ts
@@ -1,4 +1,4 @@
-/// <reference path="cosmos-keys.d.ts" />
+import { Wallet, StoredWallet } from './types';
 
 const CryptoJS = require('crypto-js')
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
+export * from './types'
 export * from './cosmos-keys'
 export * from './cosmos-keystore'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,26 +1,26 @@
-declare interface KeyPair {
+export interface KeyPair {
   privateKey: Buffer
   publicKey: Buffer
 }
-declare interface Wallet {
+export interface Wallet {
   privateKey: string
   publicKey: string
   cosmosAddress: string
 }
-declare interface StoredWallet {
+export interface StoredWallet {
   name: string
   address: string
   wallet: string // encrypted wallet
 }
-declare interface Coin {
+export interface Coin {
   denom: string
   amount: string
 }
-declare interface Fee {
+export interface Fee {
   amount: Coin[]
   gas: string
 }
-declare interface StdSignMsg {
+export interface StdSignMsg {
   chain_id: string
   account_number: string
   sequence: string


### PR DESCRIPTION
Fixes: https://github.com/luniehq/cosmos-keys/issues/11

Currently, the npm package does not include the types declared globally in `cosmos-keys.d.ts`. This PR modifies the package so that the resulting types are included as a `types.ts` file in the resulting npm package.

The alternative solution would be to create a separate "types" package for the type declarations, as described here: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html