### PR TITLE
Possibility to add custom hd path

### DIFF
--- a/src/cosmos-keys.ts
+++ b/src/cosmos-keys.ts
@@ -30,9 +30,9 @@ export function randomBytes(size: number, window = windowObject): Buffer {
   )
 }
 
-export function getNewWalletFromSeed(mnemonic: string, bech32Prefix: string): Wallet {
+export function getNewWalletFromSeed(mnemonic: string, bech32Prefix: string, hdPath: string = hdPathAtom): Wallet {
   const masterKey = deriveMasterKey(mnemonic)
-  const { privateKey, publicKey } = deriveKeypair(masterKey)
+  const { privateKey, publicKey } = deriveKeypair(masterKey, hdPath)
   const cosmosAddress = getCosmosAddress(publicKey, bech32Prefix)
   return {
     privateKey: privateKey.toString('hex'),
@@ -75,8 +75,8 @@ function deriveMasterKey(mnemonic: string): bip32.BIP32Interface {
   return masterKey
 }
 
-function deriveKeypair(masterKey: bip32.BIP32Interface): KeyPair {
-  const cosmosHD = masterKey.derivePath(hdPathAtom)
+function deriveKeypair(masterKey: bip32.BIP32Interface, hdPath: string): KeyPair {
+  const cosmosHD = masterKey.derivePath(hdPath)
   const privateKey = cosmosHD.privateKey as Buffer
 
   const publicKey = secp256k1.publicKeyCreate(privateKey, true)

--- a/src/cosmos-keys.ts
+++ b/src/cosmos-keys.ts
@@ -51,10 +51,11 @@ export function getSeed(randomBytesFunc: (size: number) => Buffer = randomBytes)
 
 export function getNewWallet(
   randomBytesFunc: (size: number) => Buffer = randomBytes,
-  bech32Prefix: string
+  bech32Prefix: string,
+  hdPath: string = hdPathAtom
 ): Wallet {
   const mnemonic = getSeed(randomBytesFunc)
-  return getNewWalletFromSeed(mnemonic, bech32Prefix)
+  return getNewWalletFromSeed(mnemonic, bech32Prefix, hdPath)
 }
 
 // NOTE: this only works with a compressed public key (33 bytes)

--- a/test/keys.spec.ts
+++ b/test/keys.spec.ts
@@ -35,6 +35,11 @@ describe(`Key Generation`, () => {
       privateKey: `a9f1c24315bf0e366660a26c5819b69f242b5d7a293fc5a3dec8341372544be8`,
       publicKey: `037a525043e79a9051d58214a9a2a70b657b3d49124dcd0acc4730df5f35d74b32`
     })
+    expect(await getNewWalletFromSeed(`a b c`, 'mesgtest', "44'/470'/0'/0/0")).toEqual({
+      cosmosAddress: `mesgtest1wna6lpw7e2yv9u2vxw4zl5vg223yf56fuadzsa`,
+      privateKey: `bab0764add9eaa7a9a61fdb61c3cd80404bf912543079fe6edcb36ec3b9c21d7`,
+      publicKey: `02eb47a78f460f91a481ddfdf5f5fa7979389d7c994e92e58d9f2b88af2dcf1866`
+    })
   })
 
   it(`create a seed`, () => {


### PR DESCRIPTION
It is now possible to use a specific `hdPath` when using the function `getNewWalletFromSeed`.
The parameter is optional and will have the `hdPathAtom` by default but can be customized.