### PR TITLE
Add network field to wallet record on localStorage

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "lodash.camelcase": "^4.3.0",
     "prettier": "^1.14.3",
     "rimraf": "^2.6.2",
+    "simsala": "0.0.18",
     "ts-jest": "^24.1.0",
     "ts-loader": "^6.0.2",
     "ts-node": "^7.0.1",

--- a/pending/aleksey_add_network_to_wallet_record
+++ b/pending/aleksey_add_network_to_wallet_record
@@ -1,0 +1,1 @@
+[Added] [#30](https://github.com/cosmos/lunie/issues/30) Storing network value in wallet @iambeone

--- a/src/cosmos-keystore.ts
+++ b/src/cosmos-keystore.ts
@@ -1,4 +1,4 @@
-import { Wallet, StoredWallet } from './types';
+import { Wallet, StoredWallet } from './types'
 
 const CryptoJS = require('crypto-js')
 
@@ -33,7 +33,12 @@ export function getStoredWallet(address: string, password: string): Wallet {
 }
 
 // store a wallet encrypted in localstorage
-export function storeWallet(wallet: Wallet, name: string, password: string, network?: string): void {
+export function storeWallet(
+  wallet: Wallet,
+  name: string,
+  password: string,
+  network: string
+): void {
   const storedWallet = loadFromStorage(wallet.cosmosAddress)
   if (storedWallet) {
     throw new Error("The wallet was already stored. Can't store the same wallet again.")
@@ -86,7 +91,7 @@ function loadFromStorage(address: string): StoredWallet | null {
 }
 
 // stores an encrypted wallet in localstorage
-function addToStorage(name: string, address: string, ciphertext: string, network?: string): void {
+function addToStorage(name: string, address: string, ciphertext: string, network: string): void {
   addToIndex(name, address)
 
   const storedWallet: StoredWallet = {

--- a/src/cosmos-keystore.ts
+++ b/src/cosmos-keystore.ts
@@ -33,14 +33,14 @@ export function getStoredWallet(address: string, password: string): Wallet {
 }
 
 // store a wallet encrypted in localstorage
-export function storeWallet(wallet: Wallet, name: string, password: string): void {
+export function storeWallet(wallet: Wallet, name: string, password: string, network?: string): void {
   const storedWallet = loadFromStorage(wallet.cosmosAddress)
   if (storedWallet) {
     throw new Error("The wallet was already stored. Can't store the same wallet again.")
   }
 
   const ciphertext = encrypt(JSON.stringify(wallet), password)
-  addToStorage(name, wallet.cosmosAddress, ciphertext)
+  addToStorage(name, wallet.cosmosAddress, ciphertext, network)
 }
 
 // store a wallet encrypted in localstorage
@@ -86,13 +86,14 @@ function loadFromStorage(address: string): StoredWallet | null {
 }
 
 // stores an encrypted wallet in localstorage
-function addToStorage(name: string, address: string, ciphertext: string): void {
+function addToStorage(name: string, address: string, ciphertext: string, network?: string): void {
   addToIndex(name, address)
 
   const storedWallet: StoredWallet = {
     name,
     address,
-    wallet: ciphertext
+    wallet: ciphertext,
+    network
   }
 
   localStorage.setItem(KEY_TAG + '-' + address, JSON.stringify(storedWallet))

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ export interface StoredWallet {
   name: string
   address: string
   wallet: string // encrypted wallet
-  network?: string
+  network: string
 }
 export interface Coin {
   denom: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface StoredWallet {
   name: string
   address: string
   wallet: string // encrypted wallet
+  network?: string
 }
 export interface Coin {
   denom: string

--- a/test/keystore.spec.ts
+++ b/test/keystore.spec.ts
@@ -4,7 +4,8 @@ const mockWallet = {
   cosmosAddress: `cosmos1r5v5srda7xfth3hn2s26txvrcrntldjumt8mhl`,
   mnemonic: `abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art`,
   privateKey: `8088c2ed2149c34f6d6533b774da4e1692eb5cb426fdbaef6898eeda489630b7`,
-  publicKey: `02ba66a84cf7839af172a13e7fc9f5e7008cb8bca1585f8f3bafb3039eda3c1fdd`
+  publicKey: `02ba66a84cf7839af172a13e7fc9f5e7008cb8bca1585f8f3bafb3039eda3c1fdd`,
+  network: `cosmos-hub-testnet`
 }
 const mockWallet2 = Object.assign({}, mockWallet, {
   cosmosAddress: `cosmos1r5v5srda7xfth3hn2s26txvrcrntldjumt8mh2`
@@ -22,25 +23,27 @@ describe(`Keystore`, () => {
   })
 
   it(`stores a wallet`, () => {
-    storeWallet(mockWallet, 'mock-name', 'mock-password')
+    storeWallet(mockWallet, 'mock-name', 'mock-password', 'regen-testnet')
     expect(
       localStorage.getItem(`cosmos-wallets-cosmos1r5v5srda7xfth3hn2s26txvrcrntldjumt8mhl`)
     ).toBeDefined()
   })
 
-  it(`check network is set`, () => {
+  it(`check if network is set`, () => {
     storeWallet(mockWallet4, 'mock-name4', 'mock-password', 'regen-testnet')
     expect(
       localStorage.getItem(`cosmos-wallets-xrn:1h0y77r8ee28hs0wqg9css7rzegmagaamwl6rdp`)
     ).toBeDefined()
-    const wallet = JSON.parse(localStorage.getItem(`cosmos-wallets-xrn:1h0y77r8ee28hs0wqg9css7rzegmagaamwl6rdp`) || '[]')
+    const wallet = JSON.parse(
+      localStorage.getItem(`cosmos-wallets-xrn:1h0y77r8ee28hs0wqg9css7rzegmagaamwl6rdp`) || '{}'
+    )
     expect(wallet.network).toEqual('regen-testnet')
   })
 
   it(`stores a collection of wallet names to prevent name collision`, () => {
-    storeWallet(mockWallet, 'mock-name', 'mock-password')
-    storeWallet(mockWallet2, 'mock-name2', 'mock-password')
-    storeWallet(mockWallet3, 'mock-name3', 'mock-password')
+    storeWallet(mockWallet, 'mock-name', 'mock-password', 'regen-testnet')
+    storeWallet(mockWallet2, 'mock-name2', 'mock-password', 'regen-testnet')
+    storeWallet(mockWallet3, 'mock-name3', 'mock-password', 'regen-testnet')
     expect(JSON.parse(localStorage.getItem(`cosmos-wallets-index`) || '[]')).toEqual([
       {
         name: `mock-name`,
@@ -58,8 +61,8 @@ describe(`Keystore`, () => {
   })
 
   it(`prevents you from adding a wallet with the same name twice`, () => {
-    storeWallet(mockWallet, 'mock-name', 'mock-password')
-    expect(() => storeWallet(mockWallet2, 'mock-name', 'mock-password2')).toThrow()
+    storeWallet(mockWallet, 'mock-name', 'mock-password', 'regen-testnet')
+    expect(() => storeWallet(mockWallet2, 'mock-name', 'mock-password2', 'regen-testnet')).toThrow()
 
     expect(JSON.parse(localStorage.getItem(`cosmos-wallets-index`) || '[]')).toEqual([
       {
@@ -70,7 +73,7 @@ describe(`Keystore`, () => {
   })
 
   it(`loads a stored wallet`, () => {
-    storeWallet(mockWallet, 'mock-name', 'mock-password')
+    storeWallet(mockWallet, 'mock-name', 'mock-password', 'regen-testnet')
     const key = getStoredWallet(mockWallet.cosmosAddress, 'mock-password')
     expect(key.privateKey).toBe(mockWallet.privateKey)
   })
@@ -80,12 +83,12 @@ describe(`Keystore`, () => {
   })
 
   it(`signals if the password for the stored wallet is incorrect`, () => {
-    storeWallet(mockWallet, 'mock-name', 'mock-password')
+    storeWallet(mockWallet, 'mock-name', 'mock-password', 'regen-testnet')
     expect(() => getStoredWallet(mockWallet.cosmosAddress, 'wrong-password')).toThrow()
   })
 
   it(`tests if a password is correct for a localy stored key`, () => {
-    storeWallet(mockWallet, 'mock-name', 'mock-password')
+    storeWallet(mockWallet, 'mock-name', 'mock-password', 'regen-testnet')
     expect(() => testPassword(mockWallet.cosmosAddress, 'mock-password')).not.toThrow()
     expect(() => testPassword(mockWallet.cosmosAddress, 'wrong-password')).toThrow()
   })
@@ -95,18 +98,18 @@ describe(`Keystore`, () => {
   })
 
   it(`prevents you from overwriting existing key names`, () => {
-    storeWallet(mockWallet, 'mock-name', 'mock-password')
-    expect(() => storeWallet(mockWallet, 'mock-name', 'mock-password')).toThrow()
+    storeWallet(mockWallet, 'mock-name', 'mock-password', 'regen-testnet')
+    expect(() => storeWallet(mockWallet, 'mock-name', 'mock-password', 'regen-testnet')).toThrow()
   })
 
   it(`prevents you from overwriting existing wallets`, () => {
-    storeWallet(mockWallet, 'mock-name', 'mock-password')
-    expect(() => storeWallet(mockWallet, 'mock-name2', 'mock-password')).toThrow()
+    storeWallet(mockWallet, 'mock-name', 'mock-password', 'regen-testnet')
+    expect(() => storeWallet(mockWallet, 'mock-name2', 'mock-password', 'regen-testnet')).toThrow()
   })
 
   it(`removes a wallet`, () => {
-    storeWallet(mockWallet, 'mock-name', 'mock-password')
-    storeWallet(mockWallet2, 'mock-name2', 'mock-password')
+    storeWallet(mockWallet, 'mock-name', 'mock-password', 'regen-testnet')
+    storeWallet(mockWallet2, 'mock-name2', 'mock-password', 'regen-testnet')
     removeWallet(mockWallet.cosmosAddress, 'mock-password')
     expect(() => getStoredWallet(mockWallet.cosmosAddress, 'mock-password')).toThrow()
     expect(JSON.parse(localStorage.getItem(`cosmos-wallets-index`) || '[]')).toEqual([
@@ -118,7 +121,7 @@ describe(`Keystore`, () => {
   })
 
   it(`throws if the password for a wallet while removing is incorrect`, () => {
-    storeWallet(mockWallet, 'mock-name', 'mock-password')
+    storeWallet(mockWallet, 'mock-name', 'mock-password', 'regen-testnet')
     expect(() => removeWallet(mockWallet.cosmosAddress, 'wrong-password')).toThrow()
     expect(() => getStoredWallet(mockWallet.cosmosAddress, 'mock-password')).not.toThrow()
   })

--- a/test/keystore.spec.ts
+++ b/test/keystore.spec.ts
@@ -12,6 +12,9 @@ const mockWallet2 = Object.assign({}, mockWallet, {
 const mockWallet3 = Object.assign({}, mockWallet, {
   cosmosAddress: `cosmos1r5v5srda7xfth3hn2s26txvrcrntldjumt8mh3`
 })
+const mockWallet4 = Object.assign({}, mockWallet, {
+  cosmosAddress: `xrn:1h0y77r8ee28hs0wqg9css7rzegmagaamwl6rdp`
+})
 
 describe(`Keystore`, () => {
   beforeEach(() => {
@@ -23,6 +26,15 @@ describe(`Keystore`, () => {
     expect(
       localStorage.getItem(`cosmos-wallets-cosmos1r5v5srda7xfth3hn2s26txvrcrntldjumt8mhl`)
     ).toBeDefined()
+  })
+
+  it(`check network is set`, () => {
+    storeWallet(mockWallet4, 'mock-name4', 'mock-password', 'regen-testnet')
+    expect(
+      localStorage.getItem(`cosmos-wallets-xrn:1h0y77r8ee28hs0wqg9css7rzegmagaamwl6rdp`)
+    ).toBeDefined()
+    const wallet = JSON.parse(localStorage.getItem(`cosmos-wallets-xrn:1h0y77r8ee28hs0wqg9css7rzegmagaamwl6rdp`) || '[]')
+    expect(wallet.network).toEqual('regen-testnet')
   })
 
   it(`stores a collection of wallet names to prevent name collision`, () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -624,7 +624,7 @@ ajv@^6.1.0, ajv@^6.10.2, ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ansi-escapes@^3.0.0:
+ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
@@ -784,6 +784,14 @@ aws4@^1.8.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.0.tgz#24390e6ad61386b0a747265754d2a17219de862c"
   integrity sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==
+
+axios@^0.18.0:
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.1.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"
+  integrity sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==
+  dependencies:
+    follow-redirects "1.5.10"
+    is-buffer "^2.0.2"
 
 babel-jest@^24.9.0:
   version "24.9.0"
@@ -1228,6 +1236,11 @@ chalk@^1.0.0, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
 check-types@^8.0.3:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-8.0.3.tgz#3356cca19c889544f2d7a95ed49ce508a0ecf552"
@@ -1301,6 +1314,11 @@ cli-truncate@^0.2.1:
   dependencies:
     slice-ansi "0.0.4"
     string-width "^1.0.1"
+
+cli-width@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
+  integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
 cliui@^5.0.0:
   version "5.0.0"
@@ -1573,6 +1591,13 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   dependencies:
     ms "2.0.0"
 
@@ -2060,6 +2085,15 @@ extend@~3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
+external-editor@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
+  integrity sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
+  dependencies:
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
+    tmp "^0.0.33"
+
 extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
@@ -2208,6 +2242,13 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -2601,7 +2642,7 @@ husky@^1.0.1:
     run-node "^1.0.0"
     slash "^2.0.0"
 
-iconv-lite@0.4.24:
+iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -2677,6 +2718,25 @@ ini@^1.3.4, ini@^1.3.5:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
+inquirer@^6.2.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.2.tgz#ad50942375d036d327ff528c08bd5fab089928ca"
+  integrity sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==
+  dependencies:
+    ansi-escapes "^3.2.0"
+    chalk "^2.4.2"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.3"
+    figures "^2.0.0"
+    lodash "^4.17.12"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.4.0"
+    string-width "^2.1.0"
+    strip-ansi "^5.1.0"
+    through "^2.3.6"
+
 interpret@1.2.0, interpret@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
@@ -2729,6 +2789,11 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@^2.0.2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
+  integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
 is-callable@^1.1.4:
   version "1.1.4"
@@ -3624,7 +3689,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.13, lodash@^4.17.15:
+lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -3931,6 +3996,11 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+mute-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+  integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
+
 nan@^2.12.1, nan@^2.13.2, nan@^2.14.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
@@ -4198,6 +4268,11 @@ os-locale@^3.1.0:
     execa "^1.0.0"
     lcid "^2.0.0"
     mem "^4.0.0"
+
+os-tmpdir@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+  integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
 p-defer@^1.0.0:
   version "1.0.0"
@@ -4793,6 +4868,13 @@ rsvp@^4.8.4:
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
+run-async@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
+  integrity sha1-A3GrSuC91yDUFm19/aZP96RFpsA=
+  dependencies:
+    is-promise "^2.1.0"
+
 run-node@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
@@ -4809,6 +4891,13 @@ rxjs@^6.3.3:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.3.tgz#510e26317f4db91a7eb1de77d9dd9ba0a4899a3a"
   integrity sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.4.0:
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.4.tgz#e0777fe0d184cec7872df147f303572d414e211c"
+  integrity sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==
   dependencies:
     tslib "^1.9.0"
 
@@ -4989,6 +5078,16 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+
+simsala@0.0.18:
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/simsala/-/simsala-0.0.18.tgz#441f5e6799a896016216f07bbbc0ddf2b5a6e421"
+  integrity sha512-gB3ehpGxigdZ2+riCznVHZk4cQdqFs2c6d+p2UKZJun5KuCoEggG4WcJMGm6iF72q3nx5R8NB3OQWay4XKPN1A==
+  dependencies:
+    axios "^0.18.0"
+    commander "^2.20.0"
+    inquirer "^6.2.2"
+    semver "^6.0.0"
 
 sisteransi@^1.0.3:
   version "1.0.4"
@@ -5206,7 +5305,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.1.1:
+string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -5365,6 +5464,11 @@ through2@^2.0.0:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
+through@^2.3.6:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
 timers-browserify@^2.0.4:
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.11.tgz#800b1f3eee272e5bc53ee465a04d0e804c31211f"
@@ -5382,6 +5486,13 @@ tiny-secp256k1@^1.1.0:
     create-hmac "^1.1.7"
     elliptic "^6.4.0"
     nan "^2.13.2"
+
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
+  dependencies:
+    os-tmpdir "~1.0.2"
 
 tmpl@1.0.x:
   version "1.0.4"


### PR DESCRIPTION
Network field needed to display account network and to switch accounts in different networks.
This pr is not needed if we will decide to identify the network by address prefix.