### PR TITLE
Ana/add addressrole to stored wallet

### DIFF
--- a/pending/ana_add-addressRole-to-storedWallet
+++ b/pending/ana_add-addressRole-to-storedWallet
@@ -1,0 +1,1 @@
+[Changed] [#103](https://github.com/cosmos/lunie/pull/103) Store addressRole in StoredWallet and enrich with it WalletIndex @Bitcoinera

--- a/src/cosmos-keystore.ts
+++ b/src/cosmos-keystore.ts
@@ -39,7 +39,8 @@ export function storeWallet(
   password: string,
   network: string,
   HDPath: string = `m/44'/118'/0'/0/0`, // default
-  curve: string = `ed25519` // default
+  curve: string = `ed25519`, // default
+  addressRole: string = `none`, // default
 ): void {
   const storedWallet = loadFromStorage(wallet.cosmosAddress)
   if (storedWallet) {
@@ -47,7 +48,7 @@ export function storeWallet(
   }
 
   const ciphertext = encrypt(JSON.stringify(wallet), password)
-  addToStorage(name, wallet.cosmosAddress, ciphertext, network, HDPath, curve)
+  addToStorage(name, wallet.cosmosAddress, ciphertext, network, HDPath, curve, addressRole)
 }
 
 // store a wallet encrypted in localstorage
@@ -90,6 +91,7 @@ export function getWalletIndex(enriched: Boolean = true): WalletIndex[] {
         wallet.network = walletData.network
         wallet.HDPath = walletData.HDPath
         wallet.curve = walletData.curve
+        wallet.addressRole = walletData.addressRole
       }
       return wallet
     })
@@ -113,7 +115,8 @@ function addToStorage(
   ciphertext: string,
   network: string,
   HDPath: string,
-  curve: string
+  curve: string,
+  addressRole: string
 ): void {
   addToIndex(name, address)
 
@@ -124,6 +127,7 @@ function addToStorage(
     network,
     HDPath,
     curve,
+    addressRole
   }
 
   localStorage.setItem(KEY_TAG + '-' + address, JSON.stringify(storedWallet))

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export interface StoredWallet {
   network: string
   HDPath: string
   curve: string
+  addressRole: string
 }
 export interface WalletIndex {
   name: string
@@ -22,6 +23,7 @@ export interface WalletIndex {
   network?: string // not stored, but enriched with
   HDPath?: string // not stored, but enriched with
   curve?: string // not stored, but enriched with
+  addressRole?: string // not stored, but enriched with
 }
 export interface Coin {
   denom: string

--- a/test/keystore.spec.ts
+++ b/test/keystore.spec.ts
@@ -35,7 +35,8 @@ describe(`Keystore`, () => {
       'mock-password',
       'regen-testnet',
       `m/44'/118'/0'/0/0`,
-      'ed25519'
+      'ed25519',
+      'none'
     )
     expect(
       localStorage.getItem(`cosmos-wallets-cosmos1r5v5srda7xfth3hn2s26txvrcrntldjumt8mhl`)
@@ -49,7 +50,8 @@ describe(`Keystore`, () => {
       'mock-password',
       'regen-testnet',
       `m/44'/118'/0'/0/0`,
-      'ed25519'
+      'ed25519',
+      'none'
     )
     expect(
       localStorage.getItem(`cosmos-wallets-xrn:1h0y77r8ee28hs0wqg9css7rzegmagaamwl6rdp`)
@@ -67,7 +69,8 @@ describe(`Keystore`, () => {
       'mock-password',
       'regen-testnet',
       `m/44'/118'/0'/0/0`,
-      'ed25519'
+      'ed25519',
+      'none'
     )
     storeWallet(
       mockWallet2,
@@ -75,7 +78,8 @@ describe(`Keystore`, () => {
       'mock-password',
       'regen-testnet',
       `m/44'/118'/0'/0/0`,
-      'ed25519'
+      'ed25519',
+      'none'
     )
     storeWallet(
       mockWallet3,
@@ -83,7 +87,8 @@ describe(`Keystore`, () => {
       'mock-password',
       'regen-testnet',
       `m/44'/118'/0'/0/0`,
-      'ed25519'
+      'ed25519',
+      'none'
     )
     expect(JSON.parse(localStorage.getItem(`cosmos-wallets-index`) || '[]')).toEqual([
       {
@@ -108,7 +113,8 @@ describe(`Keystore`, () => {
       'mock-password',
       'regen-testnet',
       `m/44'/118'/0'/0/0`,
-      'ed25519'
+      'ed25519',
+      'none'
     )
     expect(() =>
       storeWallet(
@@ -117,7 +123,8 @@ describe(`Keystore`, () => {
         'mock-password2',
         'regen-testnet',
         `m/44'/118'/0'/0/0`,
-        'ed25519'
+        'ed25519',
+        'none'
       )
     ).toThrow()
 
@@ -136,7 +143,8 @@ describe(`Keystore`, () => {
       'mock-password',
       'regen-testnet',
       `m/44'/118'/0'/0/0`,
-      'ed25519'
+      'ed25519',
+      'none'
     )
     const key = getStoredWallet(mockWallet.cosmosAddress, 'mock-password')
     expect(key.privateKey).toBe(mockWallet.privateKey)
@@ -153,7 +161,8 @@ describe(`Keystore`, () => {
       'mock-password',
       'regen-testnet',
       `m/44'/118'/0'/0/0`,
-      'ed25519'
+      'ed25519',
+      'none'
     )
     expect(() => getStoredWallet(mockWallet.cosmosAddress, 'wrong-password')).toThrow()
   })
@@ -165,7 +174,8 @@ describe(`Keystore`, () => {
       'mock-password',
       'regen-testnet',
       `m/44'/118'/0'/0/0`,
-      'ed25519'
+      'ed25519',
+      'none'
     )
     expect(() => testPassword(mockWallet.cosmosAddress, 'mock-password')).not.toThrow()
     expect(() => testPassword(mockWallet.cosmosAddress, 'wrong-password')).toThrow()
@@ -182,7 +192,8 @@ describe(`Keystore`, () => {
       'mock-password',
       'regen-testnet',
       `m/44'/118'/0'/0/0`,
-      'ed25519'
+      'ed25519',
+      'none'
     )
     expect(() =>
       storeWallet(
@@ -191,7 +202,8 @@ describe(`Keystore`, () => {
         'mock-password',
         'regen-testnet',
         `m/44'/118'/0'/0/0`,
-        'ed25519'
+        'ed25519',
+        'none'
       )
     ).toThrow()
   })
@@ -203,7 +215,8 @@ describe(`Keystore`, () => {
       'mock-password',
       'regen-testnet',
       `m/44'/118'/0'/0/0`,
-      'ed25519'
+      'ed25519',
+      'none'
     )
     expect(() =>
       storeWallet(
@@ -212,7 +225,8 @@ describe(`Keystore`, () => {
         'mock-password',
         'regen-testnet',
         `m/44'/118'/0'/0/0`,
-        'ed25519'
+        'ed25519',
+        'none'
       )
     ).toThrow()
   })
@@ -224,7 +238,8 @@ describe(`Keystore`, () => {
       'mock-password',
       'regen-testnet',
       `m/44'/118'/0'/0/0`,
-      'ed25519'
+      'ed25519',
+      'none'
     )
     storeWallet(
       mockWallet2,
@@ -232,7 +247,8 @@ describe(`Keystore`, () => {
       'mock-password',
       'regen-testnet',
       `m/44'/118'/0'/0/0`,
-      'ed25519'
+      'ed25519',
+      'none'
     )
     removeWallet(mockWallet.cosmosAddress, 'mock-password')
     expect(() => getStoredWallet(mockWallet.cosmosAddress, 'mock-password')).toThrow()
@@ -251,7 +267,8 @@ describe(`Keystore`, () => {
       'mock-password',
       'regen-testnet',
       `m/44'/118'/0'/0/0`,
-      'ed25519'
+      'ed25519',
+      'none'
     )
     expect(() => removeWallet(mockWallet.cosmosAddress, 'wrong-password')).toThrow()
     expect(() => getStoredWallet(mockWallet.cosmosAddress, 'mock-password')).not.toThrow()
@@ -268,7 +285,8 @@ describe(`Keystore`, () => {
       'mock-password',
       'regen-testnet',
       `m/44'/118'/0'/0/0`,
-      'ed25519'
+      'ed25519',
+      'none'
     )
     storeWallet(
       mockWallet2,
@@ -276,7 +294,8 @@ describe(`Keystore`, () => {
       'mock-password',
       'regen-testnet',
       `m/44'/118'/0'/0/0`,
-      'ed25519'
+      'ed25519',
+      'none'
     )
     storeWallet(
       mockWallet3,
@@ -284,7 +303,8 @@ describe(`Keystore`, () => {
       'mock-password',
       'regen-testnet',
       `m/44'/118'/0'/0/0`,
-      'ed25519'
+      'ed25519',
+      'none'
     )
     // get enriched version
     const wallets = getWalletIndex()
@@ -294,7 +314,8 @@ describe(`Keystore`, () => {
         name: 'mock-name2',
         network: 'regen-testnet',
         HDPath: "m/44'/118'/0'/0/0",
-        curve: 'ed25519'
+        curve: 'ed25519',
+        addressRole: 'none'
       },
     ]
     expect(wallets).toEqual(expect.arrayContaining(expectedValue))


### PR DESCRIPTION
Related to luniehq/lunie#4665

Store addressRole in keystore so we can display it for every Substrate/Polkadot address in UserMenu no matter if it is the current session or not